### PR TITLE
Add .mjs files as transpileable files

### DIFF
--- a/packages/@vue/cli-plugin-babel/index.js
+++ b/packages/@vue/cli-plugin-babel/index.js
@@ -25,7 +25,7 @@ module.exports = (api, options) => {
 
     const jsRule = webpackConfig.module
       .rule('js')
-        .test(/\.jsx?$/)
+        .test(/\.m?jsx?$/)
         .exclude
           .add(filepath => {
             // always transpile js in vue files


### PR DESCRIPTION
I'm not 100% sure but the option transpileDependencies in vue.config.js did not work for dependencies that use .mjs files. This small regex change fixes that problem.